### PR TITLE
Return shell command exit codes and log stdout and stderr.

### DIFF
--- a/src/main/groovy/pluggable/configuration/EnvVarProperty.groovy
+++ b/src/main/groovy/pluggable/configuration/EnvVarProperty.groovy
@@ -166,6 +166,11 @@ public class EnvVarProperty {
   * @return STDOUT logger.
   */
   public PrintStream getLogger(){
+
+    if (!this.hasProperty("out")){
+      return null;
+    }
+
     return this.bindings.out;
   }
 

--- a/src/main/groovy/pluggable/scm/helpers/Logger.groovy
+++ b/src/main/groovy/pluggable/scm/helpers/Logger.groovy
@@ -10,12 +10,21 @@ public class Logger {
   private static final EnvVarProperty envVarProperty = EnvVarProperty.getInstance();
 
   /**
-  * Print to the stdout logger with a INFO presecence.
+  * Print to the stdout logger with a INFO precedence.
   *
   *  @param msg the message to log.
   */
   public static void info(String msg){
     log(LogLevel.INFO, msg);
+  }
+
+  /**
+  * Print to the stdout logger with a ERROR precedence.
+  *
+  *  @param msg the message to log.
+  */
+  public static void error(String msg){
+    log(LogLevel.ERROR, msg);
   }
 
   /**
@@ -25,6 +34,31 @@ public class Logger {
   * @param msg the message to log.
   */
   public static void log(LogLevel logLvl, String msg){
-    envVarProperty.getLogger().println("[" + logLvl.toString() + "] - " +  msg);
+    def logger = envVarProperty.getLogger();
+
+    String message = "[" + logLvl.toString() + "] - " +  msg;
+
+    //print to stdout
+    if(logger == null){
+      println(message);
+    }else{
+      logger.println(message);
+    }
+  }
+
+  /**
+  * Print to the stdout logger with the specified message.
+  *
+  * @param msg the message to log.
+  */
+  public static void log(String msg){
+    def logger = envVarProperty.getLogger();
+
+    //print to stdout
+    if(logger == null){
+      println(msg);
+    }else{
+      logger.println(msg);
+    }
   }
 }

--- a/src/test/groovy/pluggable/scm/helpers/ExecuteShellCommandTest.groovy
+++ b/src/test/groovy/pluggable/scm/helpers/ExecuteShellCommandTest.groovy
@@ -1,0 +1,78 @@
+
+import pluggable.scm.helpers.ExecuteShellCommand;
+
+public class ExecuteShellCommandTest extends GroovyTestCase {
+
+  public void testReplacement(){
+
+    ExecuteShellCommand command = new ExecuteShellCommand();
+
+    assertEquals  "git clone https://******@github.com/Accenture/adop-pluggable-scm.git",
+      command.sanitizeCommand("git clone https://dummy:dummy@github.com/Accenture/adop-pluggable-scm.git");
+  }
+
+  public void testReplacementSecond(){
+
+    ExecuteShellCommand command = new ExecuteShellCommand();
+
+    assertEquals  "git clone https://******@github.com/Accenture/adop-pluggable-scm.git",
+      command.sanitizeCommand("git clone https://d:d@github.com/Accenture/adop-pluggable-scm.git");
+  }
+
+  public void testSafeInputHttp(){
+
+    ExecuteShellCommand command = new ExecuteShellCommand();
+
+    assertEquals  "git clone https://github.com/Accenture/adop-pluggable-scm.git",
+      command.sanitizeCommand("git clone https://github.com/Accenture/adop-pluggable-scm.git");
+  }
+
+  public void testSafeInputSsh(){
+
+    ExecuteShellCommand command = new ExecuteShellCommand();
+
+    assertEquals  "git clone ssh://github.com/Accenture/adop-pluggable-scm.git",
+      command.sanitizeCommand("git clone ssh://github.com/Accenture/adop-pluggable-scm.git");
+  }
+
+  public void testSafeInputListFiles(){
+
+    ExecuteShellCommand command = new ExecuteShellCommand();
+
+    assertEquals  "ls -la",
+      command.sanitizeCommand("ls -la");
+  }
+
+
+  public void testSafeInputGitPushOriginRefs(){
+
+    ExecuteShellCommand command = new ExecuteShellCommand();
+
+    assertEquals  "git push origin +refs/remotes/source/*:refs/heads/*",
+      command.sanitizeCommand("git push origin +refs/remotes/source/*:refs/heads/*");
+  }
+
+  public void testUnsafeInputGitRemoteAdd(){
+
+    ExecuteShellCommand command = new ExecuteShellCommand();
+
+    assertEquals  "git remote add upstream https://******@github.com/Accenture/adop-pluggable-scm.git",
+      command.sanitizeCommand("git remote add upstream https://d:d@github.com/Accenture/adop-pluggable-scm.git");
+  }
+
+  public void testExecuteCommand(){
+
+    ExecuteShellCommand command = new ExecuteShellCommand();
+
+    assertEquals  "",
+      command.executeCommand("somecommandthatdoesnotexist");
+  }
+
+  public void testExecuteCommandNonZeroExitCode(){
+
+    ExecuteShellCommand command = new ExecuteShellCommand();
+
+    assertEquals  "",
+      command.executeCommand("grep thegodfather README.md");
+  }
+}


### PR DESCRIPTION

This PR introduces;
* improved logging for shell commands (see below)
* return non zero exit code on failed shell command
* add error logger.

Example updated output for shell commands.
```
[INFO] - git clone https://localhost/
Cloning into 'localhost'...
fatal: unable to access 'https://localhost/': Failed to connect to localhost port 443: Connection refused

[ERROR] - Command executed with: 128
```

Signed-off-by: Northard, Robert A <robert.a.northard@accenture.com>