### PR TITLE
Return shell command exit codes and log stdout and stderr.

### DIFF
--- a/src/main/groovy/pluggable/configuration/EnvVarProperty.groovy
+++ b/src/main/groovy/pluggable/configuration/EnvVarProperty.groovy
@@ -166,6 +166,11 @@ public class EnvVarProperty {
   * @return STDOUT logger.
   */
   public PrintStream getLogger(){
+
+    if (!this.hasProperty("out")){
+      return null;
+    }
+
     return this.bindings.out;
   }
 

--- a/src/main/groovy/pluggable/scm/helpers/ExecuteShellCommand.groovy
+++ b/src/main/groovy/pluggable/scm/helpers/ExecuteShellCommand.groovy
@@ -1,5 +1,11 @@
 package pluggable.scm.helpers;
 
+import pluggable.scm.helpers.Logger;
+import pluggable.scm.helpers.LogLevel;
+
+import  java.util.regex.Matcher;
+import  java.util.regex.Pattern;
+
 /**
 * Helper class to convert string input into executable bash commands.
 */
@@ -17,26 +23,41 @@ public class ExecuteShellCommand {
         throw new IllegalArgumentException("A command must be provided.")
       }
 
+      // commands may contain username/passwords.
+      Logger.log(sanitizeCommand(command));
+
       StringBuffer output = new StringBuffer();
-      Process p = null;
+      Process process = null;
+      String result = "";
 
-      try {
-          p = Runtime.getRuntime().exec(command);
-          p.waitFor();
+      process = Runtime.getRuntime().exec(command);
+      process.waitForProcessOutput(output, output);
+      result = output.toString();
 
-          BufferedReader reader =
-              new BufferedReader(
-                new InputStreamReader(p.getInputStream()));
+      Logger.log(result);
 
-          String line = "";
-
-          while ((line = reader.readLine()) != null) {
-              output.append(line + "\n");
-          }
-      } catch (Exception ex) {
-          throw ex;
+      if(process.exitValue() != 0){
+        throw new IllegalStateException("Command executed with: " + process.exitValue());
       }
 
-      return output.toString();
+      return result;
+  }
+
+  /**
+  * Return a logger friendy version of a command.
+  *
+  * @param command command to sanitize (e.g. remove username/passwords)
+  * @return a logger friendly command.
+  */
+  public String sanitizeCommand(String command){
+    Pattern pattern = Pattern.compile("\\w{1,}:\\w{1,}");
+    Matcher matcher = pattern.matcher(command);
+    String sanitizedOutput = command;
+    while(matcher.find()){
+      String sensitiveInput = matcher.group()
+      sanitizedOutput = sanitizedOutput.replaceAll(sensitiveInput, "******");
+    }
+
+    return sanitizedOutput;
   }
 }

--- a/src/main/groovy/pluggable/scm/helpers/Logger.groovy
+++ b/src/main/groovy/pluggable/scm/helpers/Logger.groovy
@@ -10,12 +10,21 @@ public class Logger {
   private static final EnvVarProperty envVarProperty = EnvVarProperty.getInstance();
 
   /**
-  * Print to the stdout logger with a INFO presecence.
+  * Print to the stdout logger with a INFO precedence.
   *
   *  @param msg the message to log.
   */
   public static void info(String msg){
     log(LogLevel.INFO, msg);
+  }
+
+  /**
+  * Print to the stdout logger with a ERROR precedence.
+  *
+  *  @param msg the message to log.
+  */
+  public static void error(String msg){
+    log(LogLevel.ERROR, msg);
   }
 
   /**
@@ -25,6 +34,31 @@ public class Logger {
   * @param msg the message to log.
   */
   public static void log(LogLevel logLvl, String msg){
-    envVarProperty.getLogger().println("[" + logLvl.toString() + "] - " +  msg);
+    def logger = envVarProperty.getLogger();
+
+    String message = "[" + logLvl.toString() + "] - " +  msg;
+
+    //print to stdout
+    if(logger == null){
+      println(message);
+    }else{
+      logger.println(message);
+    }
+  }
+
+  /**
+  * Print to the stdout logger with the specified message.
+  *
+  * @param msg the message to log.
+  */
+  public static void log(String msg){
+    def logger = envVarProperty.getLogger();
+
+    //print to stdout
+    if(logger == null){
+      println(msg);
+    }else{
+      logger.println(msg);
+    }
   }
 }

--- a/src/test/groovy/pluggable/scm/helpers/ExecuteShellCommandTest.groovy
+++ b/src/test/groovy/pluggable/scm/helpers/ExecuteShellCommandTest.groovy
@@ -1,0 +1,67 @@
+
+import pluggable.scm.helpers.ExecuteShellCommand;
+
+public class ExecuteShellCommandTest extends GroovyTestCase {
+
+  public void testExecuteCommandNull(){
+    shouldFail(IllegalArgumentException){
+      ExecuteShellCommand command = new ExecuteShellCommand();
+      command.executeCommand(null);
+    }
+  }
+
+  public void testExecuteCommandEmptyCommand(){
+    shouldFail(IllegalArgumentException){
+      ExecuteShellCommand command = new ExecuteShellCommand();
+      command.executeCommand("");
+    }
+  }
+
+  public void testSanitizeCommandUnsafeInputGitCloneHttps(){
+
+    ExecuteShellCommand command = new ExecuteShellCommand();
+
+    assertEquals  "git clone https://******@github.com/Accenture/adop-pluggable-scm.git",
+      command.sanitizeCommand("git clone https://dummy:dummy@github.com/Accenture/adop-pluggable-scm.git");
+  }
+
+  public void testSanitizeCommandUnsafeInputGitCloneSsh(){
+
+    ExecuteShellCommand command = new ExecuteShellCommand();
+
+    assertEquals  "git clone ssh://******@github.com/Accenture/adop-pluggable-scm.git",
+      command.sanitizeCommand("git clone ssh://d:d@github.com/Accenture/adop-pluggable-scm.git");
+  }
+
+  public void testSanitizeCommandSafeInputGitCloneHttp(){
+
+    ExecuteShellCommand command = new ExecuteShellCommand();
+
+    assertEquals  "git clone https://github.com/Accenture/adop-pluggable-scm.git",
+      command.sanitizeCommand("git clone https://github.com/Accenture/adop-pluggable-scm.git");
+  }
+
+  public void testSanitizeCommandSafeInputGitCloneSsh(){
+
+    ExecuteShellCommand command = new ExecuteShellCommand();
+
+    assertEquals  "git clone ssh://github.com/Accenture/adop-pluggable-scm.git",
+      command.sanitizeCommand("git clone ssh://github.com/Accenture/adop-pluggable-scm.git");
+  }
+
+  public void testSanitizeCommandSafeInputListFiles(){
+
+    ExecuteShellCommand command = new ExecuteShellCommand();
+
+    assertEquals  "ls -la",
+      command.sanitizeCommand("ls -la");
+  }
+
+  public void testSanitizeCommandSafeInputGitPushOriginRefs(){
+
+    ExecuteShellCommand command = new ExecuteShellCommand();
+
+    assertEquals  "git push origin +refs/remotes/source/*:refs/heads/*",
+      command.sanitizeCommand("git push origin +refs/remotes/source/*:refs/heads/*");
+  }
+}


### PR DESCRIPTION
This PR introduces;
* improved logging for shell commands (see below)
* return non zero exit code on failed shell command (throws IllegalStateException)
* add error logger.

Example updated output for scm repo create for the Gerrit SCM provider. I can see this output getting lengthy but in my opinion it will provide a better indication of any potential errors to the end user.

```
[INFO] - Finding SCM provider for SCM provider id: adop-gerrit-ssh
[INFO] - Found properties datastore for SCM provider id: adop-gerrit-ssh
[INFO] - SCM provider type: gerrit
[INFO] - Inferring SCM provider.
[INFO] - Using class pluggable.scm.gerrit.GerritSCMProviderFactory SCM provider for type: gerrit
Custom SCM namespace specified...
cat /workspace/ExampleWorkspace/ExampleProject/Cartridge_Management/Load_Cartridge/cartridge/src/urls.txt
https://github.com/Accenture/spring-petclinic.git
https://github.com/Accenture/adop-cartridge-java-regression-tests.git
https://github.com/Accenture/adop-cartridge-java-environment-template.git

ssh -i /workspace/ExampleWorkspace/ExampleProject/Cartridge_Management/Load_Cartridge@tmp/secretFiles/21037a2f-2332-42b6-ae0b-89bf08976ec3/id_rsa -n -o StrictHostKeyChecking=no -p 29418 jenkins@gerrit gerrit ls-projects --type code
All-Users
ExampleWorkspace/ExampleProject/TEST2/adop-cartridge-java-environment-template
ExampleWorkspace/ExampleProject/TEST2/adop-cartridge-java-regression-tests
ExampleWorkspace/ExampleProject/TEST2/spring-petclinic
ExampleWorkspace/ExampleProject/TEST4/adop-cartridge-docker-reference
ExampleWorkspace/ExampleProject/TEST5/adop-cartridge-java-environment-template
ExampleWorkspace/ExampleProject/TEST5/adop-cartridge-java-regression-tests
ExampleWorkspace/ExampleProject/TEST5/spring-petclinic
ExampleWorkspace/ExampleProject/adop-cartridge-java-environment-template
ExampleWorkspace/ExampleProject/adop-cartridge-java-regression-tests
ExampleWorkspace/ExampleProject/spring-petclinic
cartridges/adop-cartridge-aspnet-linux
cartridges/adop-cartridge-cartridge-dev
cartridges/adop-cartridge-chef
cartridges/adop-cartridge-docker
cartridges/adop-cartridge-flyway
cartridges/adop-cartridge-java
platform-management

[INFO] - Found: ExampleWorkspace/ExampleProject/TEST5/spring-petclinic
[INFO] - Repository already exists, skipping create: : ExampleWorkspace/ExampleProject/TEST5/spring-petclinic
chmod +x /workspace/ExampleWorkspace/ExampleProject/Cartridge_Management/Load_Cartridge/tmp/git_ssh.sh

chmod +x /workspace/ExampleWorkspace/ExampleProject/Cartridge_Management/Load_Cartridge/tmp/shell_script.sh

/workspace/ExampleWorkspace/ExampleProject/Cartridge_Management/Load_Cartridge/tmp/shell_script.sh
Cloning into '/workspace/ExampleWorkspace/ExampleProject/Cartridge_Management/Load_Cartridge/tmp/spring-petclinic'...
Total 7481 (delta 3009), reused 7481 (delta 3009)
From https://github.com/Accenture/spring-petclinic
 * [new branch]      Cobertura  -> source/Cobertura
 * [new branch]      Spring-Security -> source/Spring-Security
 * [new branch]      angularjs  -> source/angularjs
 * [new branch]      javaconfig -> source/javaconfig
 * [new branch]      master     -> source/master
Everything up-to-date
```

Signed-off-by: Northard, Robert A <robert.a.northard@accenture.com>
