### PR TITLE
ADOPP-1215

### DIFF
--- a/site/_docs/about-pluggable-scm.md
+++ b/site/_docs/about-pluggable-scm.md
@@ -4,7 +4,7 @@ title: About Pluggable SCM Library
 permalink: /docs/about-pluggable-scm/
 ---
 
-In brief, Pluggable SCM allows user to use his own desired SCM provider, currently _BitBucket_ , _Gitlab_ and _Gerrit_ are supported.
+In brief, Pluggable SCM allows user to use their own desired SCM provider, currently _BitBucket_ , _Gitlab_ and _Gerrit_ are supported.
 
 By enabling a standard interface, Java reflection can be used to return dynamic groovy closures in cartridge which would act the same as default DSL methods depending on the SCM provider.
 

--- a/src/main/groovy/pluggable/scm/bitbucket/BitbucketSCMProvider.groovy
+++ b/src/main/groovy/pluggable/scm/bitbucket/BitbucketSCMProvider.groovy
@@ -231,10 +231,11 @@ public class BitbucketSCMProvider implements SCMProvider {
     **/
     @Override
     public Closure getMultibranch(String projectName, String repoName, String credentialId, Closure extras) {
-       if(extras == null) extras = {}
-        return {
+        if (extras == null) {
+            return {}
+        } else return {
             git extras >> {
-                remote(this.getScmUrl() + projectName + "/" + repoName + ".git" )
+                remote(this.getScmUrl() + projectName + "/" + repoName + ".git")
                 credentialsId(credentialId)
             }
         }

--- a/src/main/groovy/pluggable/scm/gerrit/GerritSCMProvider.groovy
+++ b/src/main/groovy/pluggable/scm/gerrit/GerritSCMProvider.groovy
@@ -255,10 +255,11 @@ public class GerritSCMProvider implements SCMProvider {
     **/
     @Override
     public Closure getMultibranch(String projectName, String repoName, String credentialId, Closure extras) {
-       if(extras == null) extras = {}
-        return {
+        if (extras == null) {
+            return {}
+        } else return {
             git extras >> {
-                remote(this.getScmUrl() + projectName + "/" + repoName + ".git" )
+                remote(this.getScmUrl() + projectName + "/" + repoName + ".git")
                 credentialsId(credentialId)
             }
         }

--- a/src/main/groovy/pluggable/scm/gitlab/GitlabSCMProvider.groovy
+++ b/src/main/groovy/pluggable/scm/gitlab/GitlabSCMProvider.groovy
@@ -106,15 +106,15 @@ class GitlabSCMProvider implements SCMProvider {
      * */
     @Override
     public Closure getMultibranch(String projectName, String repoName, String credentialId, Closure extras) {
-        if (extras == null) extras = {}
-        return {
+        if (extras == null) {
+            return {}
+        } else return {
             git extras >> {
                 remote(this.getScmUrl() + projectName + "/" + repoName + ".git")
                 credentialsId(credentialId)
             }
         }
     }
-
 
     /**
      * Returns a closure representation of the SCM provider's trigger SCM section for Jenkins DSL.


### PR DESCRIPTION
Pluggable was throwing an error when running Generate_SDFC_Jobs from the SFDC cartridge. This was due to the method calling all the other methods and the return function was not always useful to the pipeline so it would throw an error.
Changing it to an if-else statement resolves this issue. 